### PR TITLE
Take Engine Level into consideration

### DIFF
--- a/media/lua/client/Vehicles/TimedActions/ISRepairEngine.lua
+++ b/media/lua/client/Vehicles/TimedActions/ISRepairEngine.lua
@@ -38,6 +38,11 @@ function ISRepairEngine:perform()
 	self.item:setJobDelta(0)
 
 	local skill = self.character:getPerkLevel(Perks.Mechanics);
+	local ignoreEngineLevel = SandboxVars.CarTweaks.IgnoreEngineLevelForRepair
+	if ignoreEngineLevel == false then
+		-- subtract levels for engines with repair lvl >4
+		skill = skill - self.vehicle:getScript():getEngineRepairLevel() + 4; 
+	end
 	local numberOfParts = self.character:getInventory():getNumberOfItem("EngineParts", false, true);
 	local args = { vehicle = self.vehicle:getId(), condition = self.part:getCondition(), skillLevel = skill, numberOfParts = numberOfParts }
 	args.giveXP = self.character:getMechanicsItem(self.part:getVehicle():getMechanicalID() .. "2") == nil

--- a/media/lua/client/Vehicles/TimedActions/ISTakeEngineParts.lua
+++ b/media/lua/client/Vehicles/TimedActions/ISTakeEngineParts.lua
@@ -31,6 +31,11 @@ function ISTakeEngineParts:perform()
 	self.item:setJobDelta(0)
 
 	local skill = self.character:getPerkLevel(Perks.Mechanics);
+	local ignoreEngineLevel = SandboxVars.CarTweaks.IgnoreEngineLevelForTake
+	if ignoreEngineLevel == false then
+		-- subtract levels for engines with repair lvl >4
+		skill = skill - self.vehicle:getScript():getEngineRepairLevel() + 4; 
+	end
 	local args = { vehicle = self.vehicle:getId(), skillLevel = skill, addXp = shouldAddXp }
 	args.giveXP = self.character:getMechanicsItem(self.part:getVehicle():getMechanicalID() .. "3") == nil
 

--- a/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -1,0 +1,7 @@
+Sandbox_EN = {
+	Sandbox_CarTweaks = "Car Tweaks",
+	Sandbox_CarTweaksIgnoreEngineLevelForTake = "Ignore Engine Level for Take Engine Parts",
+	Sandbox_CarTweaksIgnoreEngineLevelForTake_tooltip = "If disabled, higher engine levels will gain less engine parts.",
+	Sandbox_CarTweaksIgnoreEngineLevelForRepair = "Ignore Engine Level for Repair Engine Action",
+	Sandbox_CarTweaksIgnoreEngineLevelForRepair_tooltip = "If disabled, higher engine levels will repair less per engine part."
+	}

--- a/media/sandbox-options.txt
+++ b/media/sandbox-options.txt
@@ -1,0 +1,13 @@
+VERSION = 1,
+
+option CarTweaks.IgnoreEngineLevelForTake
+{
+	type = boolean, default = true,
+	page = CarTweaks, translation = CarTweaksIgnoreEngineLevelForTake,
+}
+
+option CarTweaks.IgnoreEngineLevelForRepair
+{
+	type = boolean,  default = true,
+	page = CarTweaks, translation = CarTweaksIgnoreEngineLevelForRepair,
+}


### PR DESCRIPTION
Engines with repair level higher than 4 will reduce players effective skill level for all calculations.
Adds SandBoxVars to toggle, one for take and one for repair. I would advice to change default to false, but that's OP's decision.